### PR TITLE
Add "Auto Mark" menu item and seed migration

### DIFF
--- a/MarkMe.Database/AppDbContext.cs
+++ b/MarkMe.Database/AppDbContext.cs
@@ -579,21 +579,24 @@ namespace MarkMe.Database
                 new Menu { MenuId = 3, Label = "Courses", Url = "courses", Role = Role.Admin },
                 new Menu { MenuId = 4, Label = "Students", Url = "students", Role = Role.Admin },
                 new Menu { MenuId = 5, Label = "Class Representative", Url = "class-representatives", Role = Role.Admin },
+                new Menu { MenuId = 6, Label = "Auto Mark", Url = "automark", Role = Role.Admin },
 
-                new Menu { MenuId = 6, Label = "Mark Attendance", Url = "attendance", Role = Role.Tutor },
-                new Menu { MenuId = 7, Label = "Export/Share", Url = "export", Role = Role.Tutor },
-                new Menu { MenuId = 8, Label = "Courses", Url = "courses", Role = Role.Tutor },
-                new Menu { MenuId = 9, Label = "Students", Url = "students", Role = Role.Tutor },
-                new Menu { MenuId = 10, Label = "Class Representative", Url = "class-representatives", Role = Role.Tutor },
+                new Menu { MenuId = 7, Label = "Mark Attendance", Url = "attendance", Role = Role.Tutor },
+                new Menu { MenuId = 8, Label = "Export/Share", Url = "export", Role = Role.Tutor },
+                new Menu { MenuId = 9, Label = "Courses", Url = "courses", Role = Role.Tutor },
+                new Menu { MenuId = 10, Label = "Students", Url = "students", Role = Role.Tutor },
+                new Menu { MenuId = 11, Label = "Class Representative", Url = "class-representatives", Role = Role.Tutor },
+                new Menu { MenuId = 12, Label = "Auto Mark", Url = "automark", Role = Role.Tutor },
 
-                new Menu { MenuId = 11, Label = "Mark Attendance", Url = "attendance", Role = Role.CR },
-                new Menu { MenuId = 12, Label = "Export/Share", Url = "export", Role = Role.CR },
+                new Menu { MenuId = 13, Label = "Mark Attendance", Url = "attendance", Role = Role.CR },
+                new Menu { MenuId = 14, Label = "Export/Share", Url = "export", Role = Role.CR },
+                new Menu { MenuId = 15, Label = "Auto Mark", Url = "automark", Role = Role.CR },
 
                 // For Readonly Purposes
-                new Menu { MenuId = 14, Label = "Export/Share", Url = "export", Role = Role.Member },
-                new Menu { MenuId = 15, Label = "Courses", Url = "courses", Role = Role.Member },
-                new Menu { MenuId = 16, Label = "Students", Url = "students", Role = Role.Member },
-                new Menu { MenuId = 17, Label = "Class Representative", Url = "class-representatives", Role = Role.Member },
+                new Menu { MenuId = 16, Label = "Export/Share", Url = "export", Role = Role.Member },
+                new Menu { MenuId = 17, Label = "Courses", Url = "courses", Role = Role.Member },
+                new Menu { MenuId = 18, Label = "Students", Url = "students", Role = Role.Member },
+                new Menu { MenuId = 19, Label = "Class Representative", Url = "class-representatives", Role = Role.Member },
             });
         }
     }

--- a/MarkMe.Database/Migrations/20250416114410_Seeded automark menu.Designer.cs
+++ b/MarkMe.Database/Migrations/20250416114410_Seeded automark menu.Designer.cs
@@ -4,6 +4,7 @@ using MarkMe.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MarkMe.Database.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416114410_Seeded automark menu")]
+    partial class Seededautomarkmenu
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MarkMe.Database/Migrations/20250416114410_Seeded automark menu.cs
+++ b/MarkMe.Database/Migrations/20250416114410_Seeded automark menu.cs
@@ -1,0 +1,199 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace MarkMe.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Seededautomarkmenu : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 6,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Auto Mark", 0, "automark" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 7,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Mark Attendance", "attendance" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 8,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Export/Share", "export" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 9,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Courses", "courses" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 10,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Students", "students" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 11,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Class Representative", 1, "class-representatives" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 12,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Auto Mark", 1, "automark" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 14,
+                column: "Role",
+                value: 2);
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 15,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Auto Mark", 2, "automark" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 16,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Export/Share", "export" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 17,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Courses", "courses" });
+
+            migrationBuilder.InsertData(
+                table: "Menus",
+                columns: new[] { "MenuId", "Label", "Role", "Url" },
+                values: new object[,]
+                {
+                    { 13, "Mark Attendance", 2, "attendance" },
+                    { 18, "Students", 3, "students" },
+                    { 19, "Class Representative", 3, "class-representatives" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 13);
+
+            migrationBuilder.DeleteData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 18);
+
+            migrationBuilder.DeleteData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 19);
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 6,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Mark Attendance", 1, "attendance" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 7,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Export/Share", "export" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 8,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Courses", "courses" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 9,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Students", "students" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 10,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Class Representative", "class-representatives" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 11,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Mark Attendance", 2, "attendance" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 12,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Export/Share", 2, "export" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 14,
+                column: "Role",
+                value: 3);
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 15,
+                columns: new[] { "Label", "Role", "Url" },
+                values: new object[] { "Courses", 3, "courses" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 16,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Students", "students" });
+
+            migrationBuilder.UpdateData(
+                table: "Menus",
+                keyColumn: "MenuId",
+                keyValue: 17,
+                columns: new[] { "Label", "Url" },
+                values: new object[] { "Class Representative", "class-representatives" });
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes changes to the `MarkMe.Database` project to add a new "Auto Mark" menu item for various roles and to update the menu IDs accordingly. The changes span across three files: `AppDbContext.cs`, a migration file, and `AppDbContextModelSnapshot.cs`.

### Menu Updates:

* [`MarkMe.Database/AppDbContext.cs`](diffhunk://#diff-5f20ddfa07fd60b3802627c23e1d4d67cd962dfa8a9bd53314793db15f71567aR582-R599): Added a new menu item "Auto Mark" for the Admin, Tutor, CR, and Member roles, and updated the menu IDs for all roles.
* [`MarkMe.Database/Migrations/20250416114410_Seeded automark menu.cs`](diffhunk://#diff-e6452bd59bef0569ef13802be1a1bf4fb5897962810b88e1e4e128d5174821d1R1-R199): Created a new migration to seed the "Auto Mark" menu item and update the existing menu items' IDs and roles.
* [`MarkMe.Database/Migrations/AppDbContextModelSnapshot.cs`](diffhunk://#diff-1b3d0eeab1db9d048f70dedaf918d5c8f817879c2c494b7e178467063163f794R471-R561): Updated the model snapshot to include the new "Auto Mark" menu item and the updated menu IDs for all roles.